### PR TITLE
fix: 상세페이지에서 category가 나올수있도록 수정 및 옵션이 없는 상품의 상세페이지에 접근 할 수 없는 오류 해결

### DIFF
--- a/src/main/java/com/fc/final7/domain/product/dto/response/ProductResponseDTO.java
+++ b/src/main/java/com/fc/final7/domain/product/dto/response/ProductResponseDTO.java
@@ -25,7 +25,7 @@ public class ProductResponseDTO {
         thumbnail = product.getThumbnail();
         productName = product.getTitle();
         productPrice = product.getPrice();
-        briefExplanation = product.getDescription().replace("\n", "</br>");
+        briefExplanation = product.getDescription().replace("\n", "</br>").replace("\r", "");
         period = product.getTerm();
     }
 

--- a/src/main/java/com/fc/final7/domain/product/dto/response/detail/ProductDetailResponseDTO.java
+++ b/src/main/java/com/fc/final7/domain/product/dto/response/detail/ProductDetailResponseDTO.java
@@ -1,6 +1,8 @@
 package com.fc.final7.domain.product.dto.response.detail;
 
+import com.fc.final7.domain.product.entity.Category;
 import com.fc.final7.domain.product.entity.Product;
+import com.fc.final7.domain.product.entity.ProductOption;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -24,15 +26,16 @@ public class ProductDetailResponseDTO {
     private String feature;
     private String flight;
     private List<ProductPeriodDTO> period = new ArrayList<>();
-    private List<ProductContentDTO> contents = new ArrayList<>();
     private List<ProductOptionDTO> options = new ArrayList<>();
+    private List<CategoryDTO> categories = new ArrayList<>();
+    private List<ProductContentDTO> contents = new ArrayList<>();
 
-    public ProductDetailResponseDTO toDTO(Product product) {
+    public ProductDetailResponseDTO toDTO(Product product, List<Category> categories, List<ProductOption> options) {
         this.productId = product.getId();
         this.thumbnail = product.getThumbnail();
         this.productName = product.getTitle();
         this.price = product.getPrice();
-        this.briefExplanation = product.getDescription();
+        this.briefExplanation = product.getDescription().replace("\n", "</br>").replace("\r", "");
         this.region = product.getRegion();
         this.feature = product.getFeature();
         this.flight = product.getFlight();
@@ -50,8 +53,9 @@ public class ProductDetailResponseDTO {
                 .sorted(Comparator.comparing(ProductContentDTO::getPriority))
                 .collect(Collectors.toList());
 
-        this.options = product.getOptions().stream()
-                .map(ProductOptionDTO::new).collect(Collectors.toList());
+        this.options = options.stream().map(ProductOptionDTO::new).collect(Collectors.toList());
+
+        this.categories = categories.stream().map(CategoryDTO::new).collect(Collectors.toList());
         return this;
     }
 }

--- a/src/main/java/com/fc/final7/domain/product/repository/datajpa/ProductOptionRepository.java
+++ b/src/main/java/com/fc/final7/domain/product/repository/datajpa/ProductOptionRepository.java
@@ -1,7 +1,11 @@
 package com.fc.final7.domain.product.repository.datajpa;
 
+import com.fc.final7.domain.product.entity.Product;
 import com.fc.final7.domain.product.entity.ProductOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
+    List<ProductOption> findAllByProduct(Product product);
 }

--- a/src/main/java/com/fc/final7/domain/product/repository/datajpa/ProductRepository.java
+++ b/src/main/java/com/fc/final7/domain/product/repository/datajpa/ProductRepository.java
@@ -14,7 +14,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query(value = "select p from Product p" +
             " join fetch p.productPeriods pp" +
             " join fetch p.productContents pc" +
-            " join fetch p.options po" +
             " where p.id = :productId")
     Optional<Product> findProductFetchJoinById(@Param("productId") Long productId);
 

--- a/src/main/java/com/fc/final7/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/fc/final7/domain/product/service/impl/ProductServiceImpl.java
@@ -6,8 +6,11 @@ import com.fc.final7.domain.product.dto.response.ProductResponseDTO;
 import com.fc.final7.domain.product.dto.request.FilteringDTO;
 import com.fc.final7.domain.product.dto.response.detail.ProductDetailResponseDTO;
 import com.fc.final7.domain.product.dto.response.detail.ReviewResponseDTO;
+import com.fc.final7.domain.product.entity.Category;
 import com.fc.final7.domain.product.entity.Product;
+import com.fc.final7.domain.product.entity.ProductOption;
 import com.fc.final7.domain.product.repository.datajpa.CategoryRepository;
+import com.fc.final7.domain.product.repository.datajpa.ProductOptionRepository;
 import com.fc.final7.domain.product.repository.datajpa.ProductRepository;
 import com.fc.final7.domain.product.service.ProductService;
 import com.fc.final7.domain.review.entity.Posting;
@@ -28,6 +31,7 @@ public class ProductServiceImpl implements ProductService{
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
+    private final ProductOptionRepository productOptionRepository;
 
 
 
@@ -49,7 +53,9 @@ public class ProductServiceImpl implements ProductService{
     @Override
     public ProductDetailResponseDTO selectProductDetail(Long productId) {
         Product product = productRepository.findProductFetchJoinById(productId).orElseThrow(NoSearchProductException::new);
-        return new ProductDetailResponseDTO().toDTO(product);
+        List<Category> categories = categoryRepository.findAllByProduct(product);
+        List<ProductOption> options = productOptionRepository.findAllByProduct(product);
+        return new ProductDetailResponseDTO().toDTO(product, categories, options);
     }
 
     // 상품 클릭시 해당 상품의 최신리뷰 3개를 반환하는 메서드

--- a/src/main/java/com/fc/final7/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/fc/final7/domain/product/service/impl/ProductServiceImpl.java
@@ -10,6 +10,7 @@ import com.fc.final7.domain.product.entity.Product;
 import com.fc.final7.domain.product.repository.datajpa.CategoryRepository;
 import com.fc.final7.domain.product.repository.datajpa.ProductRepository;
 import com.fc.final7.domain.product.service.ProductService;
+import com.fc.final7.domain.review.entity.Posting;
 import com.fc.final7.domain.review.repository.ReviewRepository;
 import com.fc.final7.global.exception.NoSearchProductException;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +55,8 @@ public class ProductServiceImpl implements ProductService{
     // 상품 클릭시 해당 상품의 최신리뷰 3개를 반환하는 메서드
     @Override
     public List<ReviewResponseDTO> selectProductDetailInReviews(Long productId, Pageable pageable) {
-        return reviewRepository.selectProductDetailReviews(productId, pageable)
+        Posting posting = Posting.POSTING;
+        return reviewRepository.selectProductDetailReviews(productId, posting, pageable)
                 .stream()
                 .map(ReviewResponseDTO::new)
                 .collect(Collectors.toList());

--- a/src/main/java/com/fc/final7/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fc/final7/domain/review/repository/ReviewRepository.java
@@ -18,8 +18,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // pageable 인터페이스는 limit 3 을 걸기 위한 용도임
     @Query(value = "select r from Review r" +
             " where r.product.id = :productId" +
+            " and r.posting = :posting" +
             " order by r.createdDate desc")
-    List<Review> selectProductDetailReviews(@Param("productId") Long productId, Pageable pageable);
+    List<Review> selectProductDetailReviews(@Param("productId") Long productId, @Param("posting") Posting posting, Pageable pageable);
 
     @Modifying
     @Query("update Review r set r.viewCount=r.viewCount+1 WHERE r.id=:reviewId")


### PR DESCRIPTION
## Motivation
상세 페이지에서 category 목록이 나올 수 있도록 DTO수정
옵션이 없는 상품을 fetch join으로 묶었을때 해당 값이 없어 NoSuchElememtException이 뜨던 에러를 해결
DELETE된 리뷰는 보여지지 않게 수정
<!-- 해결한 이슈의 카테고리와 해당 이슈넘버를 나열하세요 -->

resolve #
close #

<!-- 간단한 설명도 추가해주세요 -->

## Key Changes

<!-- 어떻게 해결했는지 과정을 나열해주세요 -->
- dce46ff41d058460df84c8cf7e35cd1d323b0753 : DELETE된 리뷰는 나오지 않도록 수정 
- 038a10aa9664c4e4ae3cedb9c453ce47344ec837 : 상품 상세페이지에 접근 했을때 해당 상품의 카테고리 목록도 반환하기 위해 DTO에 category필드 추가
- 3a937131bae7a00fd884a244dbc6c99162f9211d : 해당 상품에 옵션이 없을때 fetch join으로 묶으면 option값이 null이라 
NoSuchElememtException 이 발생해 해당 상세페이지에 접근 할 수 없는 오류를 쿼리를 분리하여 해결 
-
## To Reviewrs
<!-- 리뷰어에게 받고 싶은 피드백이나 리뷰시 알아야 할 사항을 말씀하세요 -->
ci/cd 무사히 넘어갈 수 있게 해주세요
