### PR TITLE
이메일 서비스 uuid 값 문제 수정, 발급한 JWT토큰이 Header에 담기지 않는 문제 수정, 순환참조 문제 해결

### DIFF
--- a/src/main/java/com/fc/final7/domain/jwt/JwtProvider.java
+++ b/src/main/java/com/fc/final7/domain/jwt/JwtProvider.java
@@ -36,8 +36,7 @@ public class JwtProvider {
     private final MemberRepository memberRepository;
 
     private static final String EMAIL_KEY = "email";
-    private static final String AUTHORITIES_KEY = "role";
-    private static final String url = "https://localhost:8080";
+    private static final String AUTHORITIES_KEY = "ROLE";
 
 
     public TokenDto createToken(String email, String authorities) {
@@ -79,8 +78,8 @@ public class JwtProvider {
         String requestAccessToken = resolveToken(requestAccessTokenInHeader);
 
         Authentication authentication = getAuthentication(requestAccessToken);
-        String principal = getPrincipal(requestAccessToken);
-
+        String principal = getPrincipal(requestAccessToken);  // 이메일 필요
+//        String email = getAuthentication(requestAccessToken);
         String refreshTokenInRedis = redisService.getValues("RT : " + principal);
         if (refreshTokenInRedis == null) { // Redis에 저장되어 있는 RT가 없을 경우
             return null; // -> 재로그인 요청
@@ -104,7 +103,7 @@ public class JwtProvider {
 
     public boolean validate(String requestAccessTokenInHeader) {
         String requestAccessToken = resolveToken(requestAccessTokenInHeader);
-        return validateAccessToken(requestAccessTokenInHeader); // true = 재발급
+        return validateAccessToken(requestAccessToken); // true = 재발급
     }
 
     // "Bearer {AT}"에서 {AT} 추출
@@ -180,7 +179,6 @@ public class JwtProvider {
         return String.valueOf(getClaimsFromToken(token).getExpiration());
     }
 
-
     public Authentication getAuthentication(String token) {
         String email = getClaimsFromToken(token).get(EMAIL_KEY).toString();
         UserDetails userDetails = memberDetailsService.loadUserByUsername(email);
@@ -188,7 +186,6 @@ public class JwtProvider {
     }
 
     public String getPrincipal(String requestAccessToken) {
-//        return email;
         return getAuthentication(requestAccessToken).getPrincipal().toString();
     }
 

--- a/src/main/java/com/fc/final7/domain/member/dto/MemberResponseDtoInToken.java
+++ b/src/main/java/com/fc/final7/domain/member/dto/MemberResponseDtoInToken.java
@@ -2,15 +2,13 @@ package com.fc.final7.domain.member.dto;
 
 import com.fc.final7.domain.jwt.dto.TokenDto;
 import com.fc.final7.domain.member.enums.Gender;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Builder
+@Setter
 public class MemberResponseDtoInToken {
 
     private String email;

--- a/src/main/java/com/fc/final7/domain/member/service/MemberDetailImpl.java
+++ b/src/main/java/com/fc/final7/domain/member/service/MemberDetailImpl.java
@@ -1,6 +1,7 @@
 package com.fc.final7.domain.member.service;
 
 import com.fc.final7.domain.member.entity.Member;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -8,10 +9,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 
+
 public class MemberDetailImpl implements UserDetails {
 
     private final Member member;
 
+    @Autowired
     public MemberDetailImpl(Member member) {
         this.member = member;
     }
@@ -25,7 +28,7 @@ public class MemberDetailImpl implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null;
+        return member.getPassword();
     }
 
     @Override
@@ -35,21 +38,25 @@ public class MemberDetailImpl implements UserDetails {
 
     @Override
     public boolean isAccountNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isEnabled() {
-        return false;
+        return true;
+    }
+
+    public void setEncodedPass(String encodedPass) {
+        member.updatePassword(encodedPass);
     }
 }

--- a/src/main/java/com/fc/final7/domain/member/service/MemberDetailsServiceImpl.java
+++ b/src/main/java/com/fc/final7/domain/member/service/MemberDetailsServiceImpl.java
@@ -14,7 +14,6 @@ import javax.persistence.EntityNotFoundException;
 @RequiredArgsConstructor
 public class MemberDetailsServiceImpl implements UserDetailsService {
     private final MemberRepository memberRepository;
-
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(email).orElseThrow(EntityNotFoundException::new);

--- a/src/main/java/com/fc/final7/domain/member/service/SmtpEmailService.java
+++ b/src/main/java/com/fc/final7/domain/member/service/SmtpEmailService.java
@@ -28,16 +28,17 @@ public class SmtpEmailService {
         String uuid = "";
         Member member = memberRepository.findByEmailAndPhone(email, phone).orElseThrow(EntityNotFoundException::new);
 
-        MailDto mailDto = new MailDto();
-        mailDto.setEmail(member.getEmail());
-        mailDto.setTitle("goTogether 임시비밀번호 안내 이메일 입니다.");
-        mailDto.setMessage("goTogether 임시비밀번호 안내 이메일 입니다. 회원님의 임시 비밀번호는 " + uuid + "입니다. 로그인 후 반드시 비밀번호를 변경해주세요");
 
         if (member != null) {
             uuid = resetPassword(member);
+            MailDto mailDto = new MailDto();
 
             MimeMessage mimeMessage = javaMailSender.createMimeMessage();
             MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, false); // false로 설정하면 단순 text메시지로 전달
+
+            mailDto.setEmail(member.getEmail());
+            mailDto.setTitle("goTogether 임시비밀번호 안내 이메일 입니다.");
+            mailDto.setMessage("goTogether 임시비밀번호 안내 이메일 입니다. 회원님의 임시 비밀번호는 " + uuid + "입니다. 로그인 후 반드시 비밀번호를 변경해주세요");
 
             messageHelper.setTo(mailDto.getEmail());
             messageHelper.setSubject(mailDto.getTitle());

--- a/src/main/java/com/fc/final7/global/entity/BeanClass.java
+++ b/src/main/java/com/fc/final7/global/entity/BeanClass.java
@@ -1,0 +1,15 @@
+package com.fc.final7.global.entity;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class BeanClass {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/fc/final7/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/final7/global/exception/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode{
     ENTITY_NOT_FOUND(404, "ENTITY_NOT_FOUND", "해당하는 아이디가 존재하지 않습니다"),
     INTERNAL_SERVER_ERROR(500, "SERVER-ERROR", "Server Error"),
     NULL_OR_TYPE_MISS_MATCH(400, "NULL_OR_TYPE_MISS_MATCH", "파라미터가 null 이거나 타입이 맞지 않습니다."),
-    NULL_ACCESS_REFRESH_TOKEN(401, "Unauthorized", "토큰 기간이 만료되었습니다."),
+    NULL_ACCESS_REFRESH_TOKEN(401, "Unauthorized", "로그아웃 되었습니다"),
+    NULL_ACCESS_NOT_LOGIN(401, "Unauthorized", "로그인 후에 사용가능합니다."),
     NULL_POINTER_EXCEPTION(500, "NULL_POINTER", "NULL_POINTER_EXCEPTION 오류"),
 
     PRODUCT_NOT_FOUND(404, "PRODUCT-001", "존재하지 않는 상품입니다."),

--- a/src/main/java/com/fc/final7/global/response/BaseResponse.java
+++ b/src/main/java/com/fc/final7/global/response/BaseResponse.java
@@ -27,19 +27,17 @@ public class BaseResponse<T> {
         this.data = data;
     }
 
-    public BaseResponse(String message, Integer dataSize, T data, T response) {
+    public BaseResponse(String message, Integer dataSize) {
         this.httpStatus = OK;
         this.message = message;
         this.dataSize = dataSize;
-        this.data = data;
-        this.response = response;
     }
 
     public static <T>BaseResponse<T> of(Integer dataSize, String message, T data){
         return new BaseResponse<>(dataSize, message, data);
     }
 
-    public static <T> BaseResponse<T> ofToken(String message, Integer dataSize, T data, T response){
-        return new BaseResponse<>(message, dataSize, data, response);
+    public static <T> BaseResponse<T> of(String message, Integer dataSize){
+        return new BaseResponse<>(message, dataSize);
     }
 }

--- a/src/main/java/com/fc/final7/global/security/SecurityConfig.java
+++ b/src/main/java/com/fc/final7/global/security/SecurityConfig.java
@@ -39,11 +39,6 @@ public class SecurityConfig{
 
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-    }
-
-    @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web
                 .ignoring()


### PR DESCRIPTION
이메일 서비스 uuid 값 문제 수정, 발급한 JWT토큰이 Header에 담기지 않는 문제 수정, 순환참조 문제 해결

https://github.com/7-lin/Final_Project_BE/commit/c1ca6e1eb96643fcc2af5a54d7dc5edadf316237 : 순환참조 문제 해결을 위한 빈 등록 클래스 생성
[임시 비밀번호인 uuid가 메일로 전달되지 않는 문제를 해결](https://github.com/7-lin/Final_Project_BE/commit/74b22c21f814e633bce42f55f7a033099f47609d)
[헤더에서 토큰을 가져오지 못해 작동하지 않아 주석처리했던 일부 서비스 로직의 주석을 토큰을 처리할 수 있게 되면서 주석해제](https://github.com/7-lin/Final_Project_BE/commit/828a6869118e79bb29a906b2921785079585296d)
[로그인 한 회원의 정보를 가져와 uthentication 객체를 만들지 못하던 문제해결](https://github.com/7-lin/Final_Project_BE/commit/0c9693846415000ec2b0bbf10435f744022eff1a)