### PR TITLE
리프레쉬 토큰 재발행 기능, accessToken으로 멤버정보 활용 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,8 @@ dependencies {
 
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-
+//	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+//	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 	// email
 	implementation 'org.springframework.boot:spring-boot-starter-mail:2.7.10'
 

--- a/src/main/java/com/fc/final7/domain/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/fc/final7/domain/jwt/filter/JwtFilter.java
@@ -2,6 +2,8 @@ package com.fc.final7.domain.jwt.filter;
 
 import com.fc.final7.domain.jwt.JwtProperties;
 import com.fc.final7.domain.jwt.JwtProvider;
+import com.fc.final7.global.exception.TokenExpirationException;
+import com.fc.final7.global.redis.RedisService;
 import io.jsonwebtoken.IncorrectClaimException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -19,6 +22,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+
+import static com.fc.final7.global.exception.ErrorCode.NULL_ACCESS_NOT_LOGIN;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,27 +34,34 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final JwtProperties jwtProperties;
+    private final RedisService redisService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         String token = extractBearerToken(request);
+
+       /* if (token != null && redisService.getValues(token).equals("logout")) {
+            SecurityContextHolder.clearContext();
+            log.debug("JWT token blacklisted.");
+            response.sendError(403, "블랙리스트에 등록된 JWT 토큰입니다.");
+        }*/
+
         try {
             if (token != null && jwtProvider.validate(token)) {   // 토큰 유효 검증
                 Authentication authentication = jwtProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("Save authentication in SecurityContextHolder.");
-
             }
-        }catch (IncorrectClaimException e){
+        } catch (IncorrectClaimException e) {
             SecurityContextHolder.clearContext();
             log.debug("Invalid JWT token.");
             response.sendError(403, "토큰 정보가 일치하지 않습니다.");
-        }catch (UsernameNotFoundException e){
+        } catch (UsernameNotFoundException e) {
             SecurityContextHolder.clearContext();
             log.debug("Can't find user.");
             response.sendError(403, "해당 회원을 찾을 수 없습니다.");
         }
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
     }
 
     public String extractBearerToken(HttpServletRequest request){

--- a/src/main/java/com/fc/final7/global/security/SecurityConfig.java
+++ b/src/main/java/com/fc/final7/global/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.fc.final7.domain.jwt.filter.JwtFilter;
 import com.fc.final7.domain.jwt.handler.JwtAccessDeniedHandler;
 import com.fc.final7.domain.jwt.handler.JwtAuthenticationEntryPoint;
 import com.fc.final7.domain.member.oauth.service.CustomOauth2UserService;
+import com.fc.final7.global.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +33,8 @@ public class SecurityConfig{
     private final CustomOauth2UserService customOauth2UserService;
     private final JwtProperties jwtProperties;
     private final JwtProvider jwtProvider;
+
+    private final RedisService redisService;
 //    private final Oauth2SuccessHandler oauth2SuccessHandler;
 
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
@@ -62,7 +65,7 @@ public class SecurityConfig{
 
                 .and()
                 .addFilterBefore(
-                        new JwtFilter(jwtProvider, jwtProperties),
+                        new JwtFilter(jwtProvider, jwtProperties, redisService),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .authorizeRequests().antMatchers(


### PR DESCRIPTION
## Motivation
리프레쉬 토큰 재발행 기능, accessToken으로 멤버정보 활용


## Key Changes
https://github.com/7-lin/Final_Project_BE/issues/54 [쿼리스트링이 아닌 헤더로 들어온 토큰 정보를 활용, 토큰 재발행 로직, 블랙리스트 로직 추가 및 수정](https://github.com/7-lin/Final_Project_BE/commit/905656a38d993ee4a226d53e6cef640639096c30)
https://github.com/7-lin/Final_Project_BE/issues/54 [로그아웃 한 사용자의 엑세스 토큰이 유출될 경우를 대비해 블랙리스트 기능 구현(정상작동을 안해서 수정할 예정)](https://github.com/7-lin/Final_Project_BE/commit/84c04094b545912508c26f53cb2c08541365ced3)
